### PR TITLE
K8s cluster block

### DIFF
--- a/examples/kubernetes-cluster-usage.py
+++ b/examples/kubernetes-cluster-usage.py
@@ -1,5 +1,6 @@
 from prefect import flow
 from datetime import datetime
+from prefect.blocks.kubernetes import KubernetesCluster
 from prefect.deployments import DeploymentSpec
 from prefect.flow_runners import KubernetesFlowRunner
 
@@ -12,7 +13,9 @@ def what_day_is_it(date: datetime = None):
 DeploymentSpec(
     flow=what_day_is_it,
     name="flow-deployment",
-    flow_runner=KubernetesFlowRunner(env={"MY_VARIABLE": "FOO"})
+    flow_runner=KubernetesFlowRunner(
+        cluster_config=KubernetesCluster()
+    )
 )
 
 if __name__ == "__main__":

--- a/examples/kubernetes-cluster-usage.py
+++ b/examples/kubernetes-cluster-usage.py
@@ -4,6 +4,8 @@ from prefect.blocks.kubernetes import KubernetesCluster
 from prefect.deployments import DeploymentSpec
 from prefect.flow_runners import KubernetesFlowRunner
 
+from kubernetes import config
+
 @flow
 def what_day_is_it(date: datetime = None):
     if date is None:
@@ -14,7 +16,7 @@ DeploymentSpec(
     flow=what_day_is_it,
     name="flow-deployment",
     flow_runner=KubernetesFlowRunner(
-        cluster_config=KubernetesCluster()
+        cluster_config=KubernetesCluster(context="docker-desktop")
     )
 )
 

--- a/examples/kubernetes-flow-runner.py
+++ b/examples/kubernetes-flow-runner.py
@@ -1,0 +1,19 @@
+from prefect import flow
+from datetime import datetime
+from prefect.deployments import DeploymentSpec
+from prefect.flow_runners import KubernetesFlowRunner
+
+@flow
+def what_day_is_it(date: datetime = None):
+    if date is None:
+        date = datetime.utcnow()
+    print(f"It was {date.strftime('%A')} on {date.isoformat()}")
+
+DeploymentSpec(
+    flow=what_day_is_it,
+    name="flow-deployment",
+    flow_runner=KubernetesFlowRunner(env={"MY_VARIABLE": "FOO"})
+)
+
+if __name__ == "__main__":
+    what_day_is_it("2021-01-01T02:00:19.180906")


### PR DESCRIPTION
per #22, we are implementing a `KubernetesCluster` block to be used as an optional kwarg `cluster_config` passed to `KubernetesFlowRunner`

we would like to be able to load an existing `KubernetesCluster` block or create one inline